### PR TITLE
M1 Mac Build Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple native Electron wrapper for Xbox Cloud Gaming ([xbox.com/play](xbox.com/p
 
 ## Features
 
-* Windows / Mac / Linux(?)
+* Windows / Mac (intel/Apple Silicon) / Linux(?)
 * Alt-Enter - Toggle fullscreen
 * Escape - Minimize
 
@@ -34,6 +34,9 @@ npm run make
 
 # OSX - package and create zip to ./out
 npm run make-mac
+
+# OSX Apple Silicon - package and create zip to ./out
+npm run make-mac-aarch
 ```
 
 ## Install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xbox-cloud-gaming-wrapper",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "make-mac": "electron-forge make --platform darwin",
+    "make-mac-aarch": "electron-forge make --platform darwin --arch arm64",
     "publish": "electron-forge publish",
     "lint": "echo \"No linting configured\""
   },


### PR DESCRIPTION
This script builds for M1 Mac as shown in the screenshot.

![mac-arch](https://user-images.githubusercontent.com/891002/117586012-82ad0380-b10d-11eb-8f48-7eb3a9446547.png)
